### PR TITLE
chore: 로컬 실행환경의 경우 api spec문서 생성하도록 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 
 # Local Docker Compose
 environments/docker
+
+# openApi
+open-api

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 
 import { AppService } from './app.service';
 
 @Controller()
+@ApiTags('health')
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  @Get()
+  @Get('check')
   getHello(): string {
     return this.appService.getHello();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { writeFileSync } from 'fs';
+
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -19,6 +21,10 @@ async function bootstrap() {
       .build();
     const document = SwaggerModule.createDocument(app, config);
     SwaggerModule.setup('api', app, document);
+    // 로컬 개발환경의 경우 OpenAPI JSON을 확인할 수 있도록 저장
+    if (environment === 'local') {
+      writeFileSync('open-api/open-api-spec.json', JSON.stringify(document));
+    }
   }
 
   await app.listen(servicePort);


### PR DESCRIPTION
- 로컬 실행환경의 경우 api spec문서 생성하도록 추가

openAPI SDK 생성을 위한 스펙문서 생성 업데이트 입니다.
User 서비스의 API SDK는 [여기](https://github.com/HotteokGroup/PPOTTO_USER_SDK)에서 관리할 예정입니다
패키지의 링크는 [이곳](https://www.npmjs.com/package/@ppotto/user-api-client) 입니다.